### PR TITLE
fix: failing tests after reward adjustment

### DIFF
--- a/MemeApi.Test/Extensions/MemePlaceExtensionsTest.cs
+++ b/MemeApi.Test/Extensions/MemePlaceExtensionsTest.cs
@@ -112,9 +112,9 @@ public class MemePlaceExtensionsTest
 
         // When
         var price = place.SubmissionPriceForUser(1, user, true);
-        
+
         // Then
-        price.Should().Be(-100);
+        price.Should().Be(-700);
     }
     
     [Fact]
@@ -132,9 +132,9 @@ public class MemePlaceExtensionsTest
 
         // When
         var price = place.SubmissionPriceForUser(201, user, true);
-        
+
         // Then
-        price.Should().Be(-99);
+        price.Should().Be(-699);
     }
     
     [Fact]
@@ -152,9 +152,9 @@ public class MemePlaceExtensionsTest
 
         // When
         var price = place.SubmissionPriceForUser(100, user, false);
-        
+
         // Then
-        price.Should().Be(0);
+        price.Should().Be(-600);
     }
     
     [Fact]
@@ -172,9 +172,9 @@ public class MemePlaceExtensionsTest
 
         // When
         var price = place.SubmissionPriceForUser(100, user, false);
-        
+
         // Then
-        price.Should().Be(86);
+        price.Should().Be(0);
     }
     
     [Fact]
@@ -212,8 +212,8 @@ public class MemePlaceExtensionsTest
         
         // When
         var price = place.SubmissionPriceForUser(1, user, false);
-        
+
         // Then
-        price.Should().Be(-99);
+        price.Should().Be(-699);
     }
 }

--- a/MemeApi.Test/Repositories/TopicRepositoryTest.cs
+++ b/MemeApi.Test/Repositories/TopicRepositoryTest.cs
@@ -52,9 +52,9 @@ public class TopicRepositoryTest(IntegrationTestFactory databaseFixture) : MemeT
         var text = new MemeText { Id = Guid.NewGuid().ToString(), Text = "test", Topics = [topic], ContentHash = ""};
         _context.Texts.Add(text);
         await _context.SaveChangesAsync();
-        
+
         // When
-        var result = await _votableRepository.DeleteVotable(text, owner);
+        var result = await _votableRepository.DeleteVotable(text, owner, hardDelete: true);
 
         // Then
         result.Should().BeTrue();
@@ -177,7 +177,7 @@ public class TopicRepositoryTest(IntegrationTestFactory databaseFixture) : MemeT
         await _context.SaveChangesAsync();
 
         // When
-        var result = await _votableRepository.DeleteVotable(text, user);
+        var result = await _votableRepository.DeleteVotable(text, user, hardDelete: true);
 
         // Then
         result.Should().BeTrue();

--- a/MemeApi.Test/library/DatabaseFixture.cs
+++ b/MemeApi.Test/library/DatabaseFixture.cs
@@ -44,6 +44,7 @@ public class IntegrationTestFactory : WebApplicationFactory<Program>, IAsyncLife
     public async Task ResetDatabase()
     {
         await _respawner.ResetAsync(_connection);
+        Db.ChangeTracker.Clear();
     }
 
     public async Task InitializeAsync()

--- a/MemeApi.Test/library/MemeTestBase.cs
+++ b/MemeApi.Test/library/MemeTestBase.cs
@@ -238,12 +238,14 @@ public class MemeTestBase : IAsyncLifetime
 
     public static IFormFile CreateFormFile(int size, string filename)
     {
-        var fileStream = new MemoryStream();
-        var dummyData = new byte[size];
-        fileStream.Write(dummyData, 0, size);
-        fileStream.Position = 0;
+        // PNG signature so VisualsController.IsImage() (libmagic-based) accepts it.
+        var pngHeader = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+        var totalSize = pngHeader.Length + size;
+        var bytes = new byte[totalSize];
+        Array.Copy(pngHeader, bytes, pngHeader.Length);
 
-        var file = new FormFile(fileStream, 0, size, "fileStream", filename)
+        var fileStream = new MemoryStream(bytes);
+        var file = new FormFile(fileStream, 0, totalSize, "fileStream", filename)
         {
             Headers = new HeaderDictionary(),
             ContentType = "image/png"

--- a/MemeApi.Test/library/MemeTestBase.cs
+++ b/MemeApi.Test/library/MemeTestBase.cs
@@ -238,13 +238,38 @@ public class MemeTestBase : IAsyncLifetime
 
     public static IFormFile CreateFormFile(int size, string filename)
     {
-        // PNG signature so VisualsController.IsImage() (libmagic-based) accepts it.
-        var pngHeader = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
-        var totalSize = pngHeader.Length + size;
+        var pngBytes = new byte[]
+        {
+            // PNG signature
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+            // IHDR chunk (length=13)
+            0x00, 0x00, 0x00, 0x0D,
+            0x49, 0x48, 0x44, 0x52, // "IHDR"
+            0x00, 0x00, 0x00, 0x01, // width=1
+            0x00, 0x00, 0x00, 0x01, // height=1
+            0x08, 0x02,             // bit depth=8, color type=2 (RGB)
+            0x00, 0x00, 0x00,       // compression, filter, interlace
+            0x90, 0x77, 0x53, 0xDE, // IHDR CRC
+            // IDAT chunk
+            0x00, 0x00, 0x00, 0x0C,
+            0x49, 0x44, 0x41, 0x54, // "IDAT"
+            0x08, 0xD7, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01,
+            0xE2, 0x21, 0xBC, 0x33, // IDAT CRC
+            // IEND chunk
+            0x00, 0x00, 0x00, 0x00,
+            0x49, 0x45, 0x4E, 0x44, // "IEND"
+            0xAE, 0x42, 0x60, 0x82  // IEND CRC
+        };
+
+        var totalSize = pngBytes.Length + size;
         var bytes = new byte[totalSize];
-        Array.Copy(pngHeader, bytes, pngHeader.Length);
+        Array.Copy(pngBytes, bytes, pngBytes.Length);
+
+        var random = new Random();
+        random.NextBytes(new Span<byte>(bytes, pngBytes.Length, size));
 
         var fileStream = new MemoryStream(bytes);
+
         var file = new FormFile(fileStream, 0, totalSize, "fileStream", filename)
         {
             Headers = new HeaderDictionary(),


### PR DESCRIPTION
thanks claude

for the review, please help me make sure these are fixes and not just suppressing the tests. I have a hard time telling whether these things are intended.

Fixes:
- Update MemePlaceExtensionsTest expected values to match the maxDubloonGain=700 reward formula introduced in b81a75b.
- Clear DbContext ChangeTracker after Respawner reset so stale tracked entities don't break seeding across tests.
- Pass hardDelete:true in the two TopicRepository VotableDeleted tests to match the current DeleteVotable contract.

## The very nice analysis from claude:

CI run: 51 tests, 31 passed, 19 failed, 1 skipped.

### Group 1 — MemePlaceExtensionsTest (5 fails)

Cause: commit `b81a75b` ("adjust reward for place submissions") bumped
`maxDubloonGain` 100 → 700 and `dubloonGainPerDay` 100/7 → 700/7 in
`MemeApi/library/Extensions/MemePlaceExtensions.cs`. Test expectations
in `MemeApi.Test/Extensions/MemePlaceExtensionsTest.cs` were not updated.

Fix: update expected values to match new reward formula.

| Test (line) | Inputs | Old expected | New expected |
|---|---|---|---|
| 117 | 1px, bumping, no prior submission | -100 | -700 |
| 137 | 201px, bumping, no prior submission | -99 | -699 |
| 157 | 100px, not bumping, no prior submission | 0 | -600 |
| 177 | 100px, not bumping, 1 day ago | 86 | 0 |
| 217 | 1px, not bumping, no prior submission | -99 | -699 |

### Group 2 — Controller tests (12 fails)

Cause: DB seeding throws `DbUpdateConcurrencyException` /
`duplicate key UserName="test"`. The collection-scoped DbContext in
`IntegrationTestFactory` is reused across tests. `Respawner.ResetAsync`
wipes rows but the EF Core `ChangeTracker` keeps the previously-seeded
admin (`UserName="test"`) tracked. Next `SeedDB()` adds a new admin with
same UserName → unique constraint violation, or attempts to update a
deleted row → concurrency exception.

Fix: clear `ChangeTracker` after `ResetDatabase`.

### Group 3 — TopicRepositoryTest (2 fails)

Cause: `VotableRepository.DeleteVotable` only hard-deletes when
`hardDelete: true` is passed explicitly (added in `3fcb294`
"mod flow with bot"). Tests assert `Votables.Count() == 0` but pass no
hardDelete flag → only topic association removed, row stays.

Fix: pass `hardDelete: true` in the two `*VotableDeleted` tests.
